### PR TITLE
Removendo o master do github-actions

### DIFF
--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Google Cloud SDK
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.GCP_SA }}


### PR DESCRIPTION
Removido o "master" do campo 

uses: google-github-actions/setup-gcloud